### PR TITLE
updated dockerfiles to target specific releases of box86 and box64

### DIFF
--- a/valheim.Dockerfile
+++ b/valheim.Dockerfile
@@ -21,8 +21,9 @@ RUN apt install -y \
     libstdc++6:armhf
 
 # Install the box86 to emulate x86 platform (for steamcmd cliente)
+ARG box86_release=v0.2.8
 WORKDIR /root
-RUN git clone https://github.com/ptitSeb/box86
+RUN git clone https://github.com/ptitSeb/box86 --branch $box86_release
 WORKDIR /root/box86/build
 RUN cmake .. -DRPI4ARM64=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo
 RUN make -j4; 
@@ -31,13 +32,13 @@ RUN make install
 # Install steamcmd and download the valheim server:
 WORKDIR /root/steam
 RUN curl -sqL "https://steamcdn-a.akamaihd.net/client/installer/steamcmd_linux.tar.gz" | tar zxvf -
-# RUN export DEBUGGER="/usr/local/bin/box86"
 ENV DEBUGGER "/usr/local/bin/box86"
 RUN ./steamcmd.sh +@sSteamCmdForcePlatformType linux +login anonymous +force_install_dir /root/valheim_server +app_update 896660 validate +quit
 
 ## Box64 installation
+ARG box64_release=v0.2.0
 WORKDIR /root
-RUN git clone https://github.com/ptitSeb/box64
+RUN git clone https://github.com/ptitSeb/box64 --branch $box64_release
 WORKDIR /root/box64/build
 RUN cmake .. -DRPI4ARM64=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo
 RUN make -j4; 

--- a/valheim.dodroidn2.Dockerfile
+++ b/valheim.dodroidn2.Dockerfile
@@ -21,8 +21,9 @@ RUN apt install -y \
     libstdc++6:armhf
 
 # Install the box86 to emulate x86 platform (for steamcmd cliente)
+ARG box86_release=v0.2.8
 WORKDIR /root
-RUN git clone https://github.com/ptitSeb/box86
+RUN git clone https://github.com/ptitSeb/box86 --branch $box86_release
 WORKDIR /root/box86/build
 RUN cmake .. -DODROIDN2=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo
 RUN make -j6;
@@ -31,13 +32,13 @@ RUN make install
 # Install steamcmd and download the valheim server:
 WORKDIR /root/steam
 RUN curl -sqL "https://steamcdn-a.akamaihd.net/client/installer/steamcmd_linux.tar.gz" | tar zxvf -
-# RUN export DEBUGGER="/usr/local/bin/box86"
 ENV DEBUGGER "/usr/local/bin/box86"
 RUN ./steamcmd.sh +@sSteamCmdForcePlatformType linux +login anonymous +force_install_dir /root/valheim_server +app_update 896660 validate +quit
 
 ## Box64 installation
+ARG box64_release=v0.2.0
 WORKDIR /root
-RUN git clone https://github.com/ptitSeb/box64
+RUN git clone https://github.com/ptitSeb/box64 --branch $box64_release
 WORKDIR /root/box64/build
 RUN cmake .. -DODROIDN2=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo
 RUN make -j6;


### PR DESCRIPTION
Currently when building a docker image via the dockerfiles the box86 and box64 repos are cloned from `HEAD` of their `main` branches.  Both box86 and box64 projects use discrete releases that are tagged and publicized.  The `main` branch oftentimes includes code that hasn't been fully finalized and might still be experimental.

This PR addresses this by adding `ARG`s with the dockerfiles that target specific releases.  Currently the two main releases are:

* box84: `v0.2.8`
* box64: `v0.2.0`

This allows the built docker images to be consistently built regardless of the state of the upstream repos for box86 and box64.  The downside is that the dockerfiles will need to be updated to target new releases as they come out.

This is probably a good thing anyways, as everything will have to be tested with each new release of box86 and box64.